### PR TITLE
Added support for CANDI

### DIFF
--- a/configs/algo/candi.yaml
+++ b/configs/algo/candi.yaml
@@ -1,0 +1,16 @@
+defaults:
+  - /forward_process: candi_hybrid
+
+_target_: discrete_diffusion.algorithms.candi.CANDI
+name: candi 
+backbone: dit_candi
+causal_attention: False
+ignore_bos: False
+
+shift_loss_targets: false
+
+# Step 7: configurable schedule + forward process (CANDI specific)
+# CANDI uses hybrid corruption, but is implemented in standard noise schedule API for compatibility
+noise_schedule:
+  name: inverse_cdf
+  eps: ${noise.eps}

--- a/configs/algo/candi.yaml
+++ b/configs/algo/candi.yaml
@@ -4,10 +4,12 @@ defaults:
 _target_: discrete_diffusion.algorithms.candi.CANDI
 name: candi 
 backbone: dit_candi
+T: -1
 causal_attention: False
 ignore_bos: False
-
-shift_loss_targets: false
+parameterization: subs
+time_conditioning: False
+temp: 1.0
 
 # Step 7: configurable schedule + forward process (CANDI specific)
 # CANDI uses hybrid corruption, but is implemented in standard noise schedule API for compatibility

--- a/configs/algo/candi.yaml
+++ b/configs/algo/candi.yaml
@@ -1,6 +1,7 @@
 defaults:
   - /forward_process: candi_hybrid
 
+
 _target_: discrete_diffusion.algorithms.candi.CANDI
 name: candi 
 backbone: dit_candi
@@ -16,3 +17,5 @@ temp: 1.0
 noise_schedule:
   name: inverse_cdf
   eps: ${noise.eps}
+sampler:
+  _target_: discrete_diffusion.sampling.candi_sampler.CANDI_Sampler

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -6,12 +6,12 @@ defaults:
     - learning_rate_monitor
     - sample_saver
   - /data: text8 
-  - /model: small_candi
+  - /model: tiny_candi
   - /strategy: ddp
-  - /noise: log-linear
+  - /noise: inverse-cdf
   - /lr_scheduler: constant_warmup
   - /prior: none
-  - /sampling: default
+  - /sampling: candi
   - /algo: candi
 
 seed: 1

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -5,17 +5,19 @@ defaults:
     - checkpoint_monitor
     - learning_rate_monitor
     - sample_saver
-  - /data: openwebtext
-  - /model: small
+  - /data: text8 
+  - /model: small_candi
   - /strategy: ddp
   - /noise: log-linear
   - /lr_scheduler: constant_warmup
   - /prior: none
   - /sampling: default
-  - /algo: bd3lm
+  - /algo: candi
 
 seed: 1
 
+# base directory for caching datasets and models 
+scratch_dir:  /home/patrick/.cache/discrete_diffusion
 block_size: ${model.length}
 
 neg_infinity_mode: large-finite  # large-finite / true-inf

--- a/configs/data/ag_news.yaml
+++ b/configs/data/ag_news.yaml
@@ -1,7 +1,7 @@
 train: ag_news
 valid: ag_news
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/ag_news
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/fineweb-edu.yaml
+++ b/configs/data/fineweb-edu.yaml
@@ -1,7 +1,7 @@
 train: HuggingFaceFW/fineweb-edu
 valid: openwebtext-valid  #wikitext103
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/fineweb-edu
 wrap: True
 streaming: True
 insert_train_eos: True

--- a/configs/data/lambada.yaml
+++ b/configs/data/lambada.yaml
@@ -1,7 +1,7 @@
 train: lambada
 valid: lambada
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/lambada
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/lm1b-gpt2.yaml
+++ b/configs/data/lm1b-gpt2.yaml
@@ -1,7 +1,7 @@
 train: lm1b
 valid: lm1b
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/lm1b
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/lm1b-streaming.yaml
+++ b/configs/data/lm1b-streaming.yaml
@@ -1,7 +1,7 @@
 train: lm1b
 valid: lm1b
 tokenizer_name_or_path: bert-base-uncased
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/lm1b
 wrap: False
 streaming: True
 insert_train_eos: True

--- a/configs/data/lm1b-wrap.yaml
+++ b/configs/data/lm1b-wrap.yaml
@@ -1,7 +1,7 @@
 train: lm1b
 valid: lm1b
 tokenizer_name_or_path: bert-base-uncased
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/lm1b
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/lm1b.yaml
+++ b/configs/data/lm1b.yaml
@@ -1,7 +1,7 @@
 train: lm1b
 valid: lm1b
 tokenizer_name_or_path: bert-base-uncased
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/lm1b
 wrap: False
 streaming: False
 insert_train_eos: True

--- a/configs/data/openwebtext-split.yaml
+++ b/configs/data/openwebtext-split.yaml
@@ -1,7 +1,7 @@
 train: openwebtext-train
 valid: openwebtext-valid
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/openwebtext-split
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/openwebtext-streaming.yaml
+++ b/configs/data/openwebtext-streaming.yaml
@@ -1,7 +1,7 @@
 train: openwebtext
 valid: wikitext103
 tokenizer_name_or_path: gpt2
-cache_dir: /tmp/data
+cache_dir: ${scratch_dir}/openwebtext
 wrap: True
 streaming: True
 insert_train_eos: True

--- a/configs/data/openwebtext.yaml
+++ b/configs/data/openwebtext.yaml
@@ -1,7 +1,7 @@
 train: openwebtext-train
 valid: openwebtext-valid
 tokenizer_name_or_path: gpt2
-cache_dir: /home/hk-project-p0023960/hgf_nhz3359/New_Discrete_Diffusion-main/datasets/pgm_owt/
+cache_dir: ${scratch_dir}/openwebtext
 wrap: True
 chunking: none
 streaming: False

--- a/configs/data/ptb.yaml
+++ b/configs/data/ptb.yaml
@@ -1,7 +1,7 @@
 train: ptb
 valid: ptb
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/ptb
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/scientific_papers_arxiv.yaml
+++ b/configs/data/scientific_papers_arxiv.yaml
@@ -1,7 +1,7 @@
 train: scientific_papers_arxiv
 valid: scientific_papers_arxiv
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/scientific_papers_arxiv
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/scientific_papers_pubmed.yaml
+++ b/configs/data/scientific_papers_pubmed.yaml
@@ -1,7 +1,7 @@
 train: scientific_papers_pubmed
 valid: scientific_papers_pubmed
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/scientific_papers_pubmed
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/synthetic.yaml
+++ b/configs/data/synthetic.yaml
@@ -1,7 +1,7 @@
 train: synthetic
 valid: synthetic
 tokenizer_name_or_path: synthetic
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/synthetic
 wrap: True
 streaming: True
 insert_train_eos: True

--- a/configs/data/text8-crop.yaml
+++ b/configs/data/text8-crop.yaml
@@ -2,7 +2,7 @@
 train: text8-crop
 valid: text8
 tokenizer_name_or_path: text8
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir:  ${scratch_dir}/text8-crop
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/text8.yaml
+++ b/configs/data/text8.yaml
@@ -2,7 +2,7 @@
 train: text8
 valid: text8
 tokenizer_name_or_path: text8
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/text8
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/wikitext103.yaml
+++ b/configs/data/wikitext103.yaml
@@ -1,7 +1,7 @@
 train: wikitext103
 valid: wikitext103
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/wikitext103
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/data/wikitext2.yaml
+++ b/configs/data/wikitext2.yaml
@@ -1,7 +1,7 @@
 train: wikitext2
 valid: wikitext2
 tokenizer_name_or_path: gpt2
-cache_dir: /share/kuleshov/ssahoo/textdiffusion/data
+cache_dir: ${scratch_dir}/wikitext2
 wrap: True
 streaming: False
 insert_train_eos: True

--- a/configs/eval/generate_samples.yaml
+++ b/configs/eval/generate_samples.yaml
@@ -1,4 +1,4 @@
-checkpoint_path: ???      # Path to the checkpoint file (.ckpt)
+checkpoint_path:  /home/patrick/UNI-D2/outputs/text8/2025.11.29/131912/dummy_checkpoints/checkpoints/last.ckpt
 samples_path: samples.pt  # Output path for generated samples (.pt)
 num_samples: 16           # Total number of samples to generate
 batch_size: 16            # Batch size for generation

--- a/configs/eval/generate_samples.yaml
+++ b/configs/eval/generate_samples.yaml
@@ -1,8 +1,8 @@
-checkpoint_path:  /home/patrick/UNI-D2/outputs/text8/2025.11.29/131912/dummy_checkpoints/checkpoints/last.ckpt
+checkpoint_path:  /home/patrick/UNI-D2/outputs/text8/2025.11.29/155447/dummy_checkpoints/checkpoints/last.ckpt
 samples_path: samples.pt  # Output path for generated samples (.pt)
 num_samples: 16           # Total number of samples to generate
 batch_size: 16            # Batch size for generation
 num_steps: null           # Number of denoising steps (null = use config value)
 device: cuda              # Device to run generation on
 torch_compile: false      # Whether to use torch.compile
-save_text: false          # Whether to save detokenized text samples
+save_text: true          # Whether to save detokenized text samples

--- a/configs/forward_process/candi_hybrid.yaml
+++ b/configs/forward_process/candi_hybrid.yaml
@@ -1,6 +1,6 @@
 # Hydra instantiation config for Absorbing forward process
 # Note: tokenizer and schedule must be passed at runtime
-_target_: discrete_diffusion.candi_hybrid.HybridForwardCANDI
+_target_: discrete_diffusion.forward_process.candi_hybrid.HybridForwardCANDI
 
 # Legacy name field for backward compatibility
 name: candi_hybrid 

--- a/configs/forward_process/candi_hybrid.yaml
+++ b/configs/forward_process/candi_hybrid.yaml
@@ -1,0 +1,7 @@
+# Hydra instantiation config for Absorbing forward process
+# Note: tokenizer and schedule must be passed at runtime
+_target_: discrete_diffusion.candi_hybrid.HybridForwardCANDI
+
+# Legacy name field for backward compatibility
+name: candi_hybrid 
+

--- a/configs/model/small_candi.yaml
+++ b/configs/model/small_candi.yaml
@@ -1,0 +1,23 @@
+# Hydra instantiation config for DIT model
+_target_: discrete_diffusion.models.dit_candi.DIT_CANDI
+
+# candi specific fields
+mixed_coeff: 0.5 # coefficient for biasing strength 
+
+# Legacy fields for backward compatibility
+name: small_candi
+type: ddit
+hidden_size: 768
+cond_dim: 128
+length: 1024
+n_blocks: 12
+n_heads: 12
+scale_by_sigma: True
+dropout: 0.1
+tie_word_embeddings: False
+vocab_lookup: True
+causal_attention: false
+adaln: true
+max_tokens: 1024
+attn_type: full
+attn_backend: flex

--- a/configs/model/tiny_candi.yaml
+++ b/configs/model/tiny_candi.yaml
@@ -7,11 +7,11 @@ mixed_coeff: 0.5 # coefficient for biasing strength
 # Legacy fields for backward compatibility
 name: small_candi
 type: ddit
-hidden_size: 768
+hidden_size: 256
 cond_dim: 128
 length: 128
-n_blocks: 12
-n_heads: 12
+n_blocks: 8
+n_heads: 8
 scale_by_sigma: True
 dropout: 0.1
 tie_word_embeddings: False

--- a/configs/noise/inverse-cdf.yaml
+++ b/configs/noise/inverse-cdf.yaml
@@ -1,0 +1,5 @@
+# Hydra instantiation config for InverseCDF noise schedule for CANDI
+_target_: discrete_diffusion.noise_schedules.inverse_cdf.InverseCDF
+eps: 1e-3
+r_max: .45
+r_min: .05

--- a/configs/sampling/candi.yaml
+++ b/configs/sampling/candi.yaml
@@ -1,0 +1,13 @@
+predictor: candi 
+steps: 128
+use_float64: True
+p_nucleus: 1.0
+num_sample_batches: 1
+num_sample_log: 2
+stride_length: 1
+num_strides: 1
+inject_bos: True
+save_samples: false
+samples_path: null
+sampler:
+  _target_: discrete_diffusion.sampling.candi_sampler.CANDI_Sampler

--- a/src/discrete_diffusion/algorithms/candi.py
+++ b/src/discrete_diffusion/algorithms/candi.py
@@ -1,0 +1,85 @@
+""""CANDI implementation from https://arxiv.org/abs/2510.22510"""
+
+import torch
+import torch.nn.functional as F
+from discrete_diffusion.algorithms.base import Diffusion
+import omegaconf
+import hydra
+
+class CANDI(Diffusion):
+    def __init__(self, config, tokenizer):
+        vocab_size = len(tokenizer) + 1 # accounting for mask token
+        super().__init__(config, tokenizer, vocab_size=vocab_size)
+        # getting custom forward process
+        fp_cfg = getattr(self.config.algo, "forward_process", None)
+        fp_config = omegaconf.OmegaConf.create(fp_cfg)
+        self._forward_process = hydra.utils.instantiate(
+            fp_config, tokenizer=self.tokenizer, schedule=self.noise, _recursive_=False
+        )
+        self.temp = config.algo.get("temp", 1.0)
+
+    def _validate_configuration(self):
+        # for further extension on CANDI variants, ensure that names always include "candi"
+
+        # Validate that forward process is compatible with CANDI
+        assert "candi" in self._forward_process.name.lower()
+
+        # Validate that the backbone is also compatible
+        assert "candi" in self.config.model.name 
+        return super()._validate_configuration()
+    
+    def _process_model_output(self, xt, model_output, reveal_mask): 
+        if xt.ndim == 2: 
+            xt_tokens = xt
+        else: 
+            xt_tokens = xt.argmax(dim=-1)
+
+        # if not training, apply temperature 
+        if not self.training:
+            model_output = model_output / self.temp
+        model_output = model_output - torch.logsumexp(
+            model_output, dim=-1, keepdim=True
+        )
+        reveal_mask = reveal_mask.bool()
+        model_output[reveal_mask] = self.neg_infinity
+        model_output[reveal_mask, xt_tokens[reveal_mask]] = 0
+        return model_output
+    
+    def nll_per_token(self, log_x_theta, alpha_t, dalpha_t, x0_tokens, **kwargs): 
+        """Computes the negative log-likelihood per token as in Equation 13 of CANDI paper."""
+
+        log_p_theta = torch.gather(
+            input=log_x_theta, dim=-1, index=x0_tokens[:, :, None]
+        ).squeeze(-1)
+        nll = log_p_theta * dalpha_t / (1 - alpha_t)
+        return nll
+    
+    def nll(self, x0, output_tokens, current_accumulation_step=None, train_mode=False):
+        del output_tokens  # Unused
+
+        t = self._sample_t(x0.shape[0], current_accumulation_step)
+        alpha_t = self.noise.alpha_t(t)
+        alpha_t = alpha_t.unsqueeze(-1)
+        assert alpha_t.ndim == 2
+        
+        
+        assert t.shape[0] == x0.shape[0]
+
+        noisy_input = self._forward_process.forward(x0, t)
+        log_x_theta = self.forward(**noisy_input)
+        return self.nll_per_token(
+                log_x_theta=log_x_theta, 
+                x0_tokens=x0,
+                **noisy_input,
+           ) 
+
+    def forward(self, **kwargs): 
+        model_output = self.backbone(**kwargs)
+        return self._process_model_output(model_output=model_output, xt=kwargs['xt'], reveal_mask=kwargs['reveal_mask'])
+
+    def prior_sample(self, *batch_dims): 
+        sigma = self.noise.sigma_t(torch.tensor(.999).to(self.device))
+        noise = torch.randn(
+            *batch_dims, self.vocab_size-1, dtype=torch.float32, device=self.device
+        )  * sigma
+        return noise

--- a/src/discrete_diffusion/forward_process/candi_hybrid.py
+++ b/src/discrete_diffusion/forward_process/candi_hybrid.py
@@ -1,0 +1,51 @@
+"""Hybrid Noising process for CANDI."""
+
+from __future__ import annotations
+
+import torch
+from .utils import _mask_token_id
+from .base import ForwardProcess
+from ..noise_schedules.base import NoiseSchedule
+import torch.nn.functional as F
+
+
+class HybridForwardCANDI(ForwardProcess):
+    """Hybrid noising kernel for CANDI.
+    https://arxiv.org/pdf/2510.22510 
+
+    Selects positions with probability `(1 - alpha_t)` to add Gaussian noise, with variance sigma_t.
+    Leaves others the same.
+
+    """
+
+    def __init__(
+        self, tokenizer, schedule: NoiseSchedule, name: str | None = None
+    ) -> None:
+        print(schedule)
+        
+        assert hasattr(schedule, "r_t") and hasattr(schedule, "sigma_t"), (
+            "CANDI schedule must implement r_t and sigma_t methods."
+        )
+
+        super().__init__(tokenizer=tokenizer, schedule=schedule, name=name)
+        self.mask_id = _mask_token_id(tokenizer)
+
+    @torch.no_grad()
+    def forward(self, input_ids: torch.Tensor, t: torch.Tensor):
+        """Applies hybrid noising process to input_ids at time t. Implements Equation 11 of CANDI paper."""
+        alpha_t = self.schedule.alpha_t(t).view(-1, 1)
+        dalpha_t = self.schedule.alpha_prime_t(t).view(-1, 1)
+        sigma_t = self.schedule.sigma_t(t).view(-1, 1, 1)
+        p_mask = (1.0 - alpha_t).to(dtype=torch.float32)
+
+        # get noisy positiosn
+        move_mask = (torch.rand_like(input_ids, dtype=torch.float32) < p_mask).float()
+
+        # get one-hot representations 
+        X_0 = F.one_hot(input_ids, num_classes=len(self.tokenizer)).to(input_ids.device)
+
+        X_t_prime = X_0 + torch.randn_like(X_0, dtype=torch.float32) * sigma_t
+
+        X_t = X_0 * (1 - move_mask.unsqueeze(-1)) + X_t_prime * move_mask.unsqueeze(-1)
+
+        return {"xt": X_t, "reveal_mask": 1-move_mask, "continuous_noise": sigma_t, "discrete_noise": t, "alpha_t": alpha_t, "dalpha_t": dalpha_t}  

--- a/src/discrete_diffusion/models/dit_candi.py
+++ b/src/discrete_diffusion/models/dit_candi.py
@@ -1,0 +1,533 @@
+"""DiT model architecture adapted for continuous-discrete hybrid diffusion."""
+import math
+import pdb
+import typing
+
+import einops
+import flash_attn
+import flash_attn.layers.rotary
+import huggingface_hub
+import omegaconf
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# Flags required to enable jit fusion kernels
+torch._C._jit_set_profiling_mode(False)
+torch._C._jit_set_profiling_executor(False)
+torch._C._jit_override_can_fuse_on_cpu(True)
+torch._C._jit_override_can_fuse_on_gpu(True)
+
+
+def bias_dropout_add_scale(
+    x: torch.Tensor,
+    bias: typing.Optional[torch.Tensor],
+    scale: torch.Tensor,
+    residual: typing.Optional[torch.Tensor],
+    prob: float,
+    training: bool,
+) -> torch.Tensor:
+    if bias is not None:
+        out = scale * F.dropout(x + bias, p=prob, training=training)
+    else:
+        out = scale * F.dropout(x, p=prob, training=training)
+
+    if residual is not None:
+        out = residual + out
+    return out
+
+
+def get_bias_dropout_add_scale(training):
+    def _bias_dropout_add(x, bias, scale, residual, prob):
+        return bias_dropout_add_scale(x, bias, scale, residual, prob, training)
+
+    return _bias_dropout_add
+
+
+# function overload
+def modulate(x: torch.Tensor, shift: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    return x * (1 + scale) + shift
+
+
+@torch.jit.script
+def bias_dropout_add_scale_fused_train(
+    x: torch.Tensor,
+    bias: typing.Optional[torch.Tensor],
+    scale: torch.Tensor,
+    residual: typing.Optional[torch.Tensor],
+    prob: float,
+) -> torch.Tensor:
+    return bias_dropout_add_scale(x, bias, scale, residual, prob, True)
+
+
+@torch.jit.script
+def bias_dropout_add_scale_fused_inference(
+    x: torch.Tensor,
+    bias: typing.Optional[torch.Tensor],
+    scale: torch.Tensor,
+    residual: typing.Optional[torch.Tensor],
+    prob: float,
+) -> torch.Tensor:
+    return bias_dropout_add_scale(x, bias, scale, residual, prob, False)
+
+
+@torch.jit.script
+def modulate_fused(
+    x: torch.Tensor, shift: torch.Tensor, scale: torch.Tensor
+) -> torch.Tensor:
+    return modulate(x, shift, scale)
+
+
+class Rotary(torch.nn.Module):
+    def __init__(self, dim, base=10_000):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer("inv_freq", inv_freq)
+        self.seq_len_cached = None
+        self.cos_cached = None
+        self.sin_cached = None
+
+    def forward(self, x, seq_dim=1):
+        seq_len = x.shape[seq_dim]
+        if seq_len != self.seq_len_cached:
+            self.seq_len_cached = seq_len
+            t = torch.arange(x.shape[seq_dim], device=x.device).type_as(self.inv_freq)
+            freqs = torch.einsum("i,j->ij", t, self.inv_freq.clone())
+            emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
+            # dims are: batch, seq_len, qkv, head, dim
+            self.cos_cached = emb.cos()[None, :, None, None, :].repeat(1, 1, 3, 1, 1)
+            self.sin_cached = emb.sin()[None, :, None, None, :].repeat(1, 1, 3, 1, 1)
+            # This makes the transformation on v an identity.
+            self.cos_cached[:, :, 2, :, :].fill_(1.0)
+            self.sin_cached[:, :, 2, :, :].fill_(0.0)
+
+        return self.cos_cached, self.sin_cached
+
+
+def rotate_half(x):
+    x1, x2 = x[..., : x.shape[-1] // 2], x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def split_and_apply_rotary_pos_emb(qkv, rotary_cos_sin):
+    with torch.cuda.amp.autocast(enabled=False):
+        cos, sin = rotary_cos_sin
+        cos = cos.to(qkv.dtype)
+        sin = sin.to(qkv.dtype)
+        cos = cos[0, :, 0, 0, : cos.shape[-1] // 2]
+        sin = sin[0, :, 0, 0, : sin.shape[-1] // 2]
+        q, k, v = qkv.chunk(3, dim=2)
+        q = flash_attn.layers.rotary.apply_rotary_emb_torch(q.squeeze(dim=2), cos, sin)
+        k = flash_attn.layers.rotary.apply_rotary_emb_torch(k.squeeze(dim=2), cos, sin)
+        v = v.squeeze(dim=2)
+    return q, k, v
+
+
+def apply_rotary_pos_emb(qkv, cos, sin):
+    cos = cos[0, :, 0, 0, : cos.shape[-1] // 2]
+    sin = sin[0, :, 0, 0, : sin.shape[-1] // 2]
+    return flash_attn.layers.rotary.apply_rotary_emb_qkv_(qkv, cos, sin)
+
+
+def regular_attention_multi_headed(q, k, v):
+    # Assuming qkv is a tensor with shape [batch, seq_len, 3, num_heads, head_dim]
+    # where the 3 represents Q, K, V packed in that order
+    attention_output = F.scaled_dot_product_attention(
+        query=q.transpose(1, 2),
+        key=k.transpose(1, 2),
+        value=v.transpose(1, 2),
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+    )
+    # [batch_size, seq_len, num_heads, head_dim]
+    attention_output = attention_output.transpose(1, 2)
+    return einops.rearrange(attention_output, "b s h d -> b s (h d)")
+
+
+#################################################################################
+#                                  Layers                                       #
+#################################################################################
+class LayerNorm(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones([dim]))
+        self.dim = dim
+
+    def forward(self, x):
+        with torch.cuda.amp.autocast(enabled=False):
+            x = F.layer_norm(x.float(), [self.dim])
+        return x * self.weight[None, None, :]
+
+
+def residual_linear(x, W, x_skip, residual_scale):
+    """x_skip + residual_scale * W @ x"""
+    dim_out, dim_in = W.shape[0], W.shape[1]
+    return torch.addmm(
+        x_skip.view(-1, dim_out), x.view(-1, dim_in), W.T, alpha=residual_scale
+    ).view(*x.shape[:-1], dim_out)
+
+
+#################################################################################
+#               Embedding Layers for Timesteps and Class Labels                 #
+#################################################################################
+class TimestepEmbedder(nn.Module):
+    """
+    Embeds scalar timesteps into vector representations.
+    """
+
+    def __init__(self, hidden_size, frequency_embedding_size=256):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(frequency_embedding_size, hidden_size, bias=True),
+            nn.SiLU(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+        )
+        self.frequency_embedding_size = frequency_embedding_size
+
+    @staticmethod
+    def timestep_embedding(t, dim, max_period=10000):
+        """
+        Create sinusoidal timestep embeddings.
+        :param t: a 1-D Tensor of N indices, one per batch element.
+                          These may be fractional.
+        :param dim: the dimension of the output.
+        :param max_period: controls the minimum frequency of the embeddings.
+        :return: an (N, D) Tensor of positional embeddings.
+        """
+        # https://github.com/openai/glide-text2im/blob/main/glide_text2im/nn.py
+        half = dim // 2
+        freqs = torch.exp(
+            -math.log(max_period)
+            * torch.arange(start=0, end=half, dtype=torch.float32, device=t.device)
+            / half
+        )
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat(
+                [embedding, torch.zeros_like(embedding[:, :1])], dim=-1
+            )
+        return embedding
+
+    def forward(self, t):
+        t_freq = self.timestep_embedding(t, self.frequency_embedding_size)
+        t_emb = self.mlp(t_freq)
+        return t_emb
+
+
+class LabelEmbedder(nn.Module):
+    """Embeds class labels into vector representations.
+
+    Also handles label dropout for classifier-free guidance.
+    """
+
+    def __init__(self, num_classes, cond_size):
+        super().__init__()
+        self.embedding_table = nn.Embedding(num_classes + 1, cond_size)
+        self.num_classes = num_classes
+
+        # TODO think of initializing with 0.02 std deviation like in original DiT paper
+
+    def forward(self, labels):
+        embeddings = self.embedding_table(labels)
+        return embeddings
+
+
+#################################################################################
+#                                 Core Model                                    #
+#################################################################################
+
+
+class DDiTBlockCausal(nn.Module):
+    def __init__(self, dim, n_heads, mlp_ratio=4, dropout=0.1):
+        super().__init__()
+        self.n_heads = n_heads
+
+        self.norm1 = LayerNorm(dim)
+        self.attn_qkv = nn.Linear(dim, 3 * dim, bias=False)
+        self.attn_out = nn.Linear(dim, dim, bias=False)
+        self.dropout1 = nn.Dropout(dropout)
+
+        self.norm2 = LayerNorm(dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(dim, mlp_ratio * dim, bias=True),
+            nn.GELU(approximate="tanh"),
+            nn.Linear(mlp_ratio * dim, dim, bias=True),
+        )
+        self.dropout2 = nn.Dropout(dropout)
+        self.dropout = dropout
+
+    def _get_bias_dropout_scale(self):
+        if self.training:
+            return bias_dropout_add_scale_fused_train
+        else:
+            return bias_dropout_add_scale_fused_inference
+
+    def forward(self, x, rotary_cos_sin, **kwargs):
+        del kwargs
+        batch_size, seq_len = x.shape[0], x.shape[1]
+
+        bias_dropout_scale_fn = self._get_bias_dropout_scale()
+
+        # attention operation
+        x_skip = x
+        x = self.norm1(x)
+
+        qkv = self.attn_qkv(x)
+        qkv = einops.rearrange(
+            qkv, "b s (three h d) -> b s three h d", three=3, h=self.n_heads
+        )
+        with torch.cuda.amp.autocast(enabled=False):
+            cos, sin = rotary_cos_sin
+            qkv = apply_rotary_pos_emb(qkv, cos.to(qkv.dtype), sin.to(qkv.dtype))
+        qkv = einops.rearrange(qkv, "b s ... -> (b s) ...")
+        cu_seqlens = torch.arange(
+            0,
+            (batch_size + 1) * seq_len,
+            step=seq_len,
+            dtype=torch.int32,
+            device=qkv.device,
+        )
+        x = flash_attn.flash_attn_interface.flash_attn_varlen_qkvpacked_func(
+            qkv, cu_seqlens, seq_len, 0.0, causal=True
+        )
+
+        x = einops.rearrange(x, "(b s) h d -> b s (h d)", b=batch_size)
+
+        scale = torch.ones(1, device=x.device, dtype=x.dtype)
+        x = bias_dropout_scale_fn(self.attn_out(x), None, scale, x_skip, self.dropout)
+
+        # mlp operation
+        x = bias_dropout_scale_fn(self.mlp(self.norm2(x)), None, scale, x, self.dropout)
+        return x
+
+
+class DDiTBlock(nn.Module):
+    def __init__(self, dim, n_heads, adaLN, cond_dim=None, mlp_ratio=4, dropout=0.1):
+        super().__init__()
+        self.n_heads = n_heads
+        self.adaLN = adaLN
+
+        self.norm1 = LayerNorm(dim)
+        self.attn_qkv = nn.Linear(dim, 3 * dim, bias=False)
+        self.attn_out = nn.Linear(dim, dim, bias=False)
+        self.dropout1 = nn.Dropout(dropout)
+
+        self.norm2 = LayerNorm(dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(dim, mlp_ratio * dim, bias=True),
+            nn.GELU(approximate="tanh"),
+            nn.Linear(mlp_ratio * dim, dim, bias=True),
+        )
+        self.dropout2 = nn.Dropout(dropout)
+        self.dropout = dropout
+
+        if self.adaLN:
+            self.adaLN_modulation = nn.Linear(cond_dim, 6 * dim)
+            self.adaLN_modulation.weight.data.zero_()
+            self.adaLN_modulation.bias.data.zero_()
+
+    def _get_bias_dropout_scale(self):
+        if self.training:
+            return bias_dropout_add_scale_fused_train
+        else:
+            return bias_dropout_add_scale_fused_inference
+
+    def forward(self, x, rotary_cos_sin, c=None):
+
+        bias_dropout_scale_fn = self._get_bias_dropout_scale()
+
+        x_skip = x
+        x = self.norm1(x)
+
+        if self.adaLN:
+            # self.adaLN_modulation(c): (128, 1536)
+            # self.adaLN_modulation(c)[:, None]: (128, 1, 1536)
+            # "" .chunk(6, dim=2) returns 6 tuples of shapes (128, 1, 256)
+            (
+                shift_msa,
+                scale_msa,
+                gate_msa,
+                shift_mlp,
+                scale_mlp,
+                gate_mlp,
+            ) = self.adaLN_modulation(c)[:, None].chunk(6, dim=2)
+            x = modulate_fused(x, shift_msa, scale_msa)
+
+        qkv = einops.rearrange(
+            self.attn_qkv(x),
+            "b s (three h d) -> b s three h d",
+            three=3,
+            h=self.n_heads,
+        )
+        q, k, v = split_and_apply_rotary_pos_emb(qkv, rotary_cos_sin)
+
+        x = regular_attention_multi_headed(q, k, v)
+
+        if self.adaLN:
+            x = bias_dropout_scale_fn(
+                self.attn_out(x), None, gate_msa, x_skip, self.dropout
+            )
+            x = bias_dropout_scale_fn(
+                self.mlp(modulate_fused(self.norm2(x), shift_mlp, scale_mlp)),
+                None,
+                gate_mlp,
+                x,
+                self.dropout,
+            )
+        else:
+            scale = torch.ones(1, device=x.device, dtype=x.dtype)
+            x = bias_dropout_scale_fn(
+                self.attn_out(x), None, scale, x_skip, self.dropout
+            )
+            x = bias_dropout_scale_fn(
+                self.mlp(self.norm2(x)), None, scale, x, self.dropout
+            )
+        return x
+
+
+class EmbeddingLayer(nn.Module):
+    def __init__(self, dim, vocab_dim):
+        super().__init__()
+        self.dim = dim
+        
+
+
+        self.embedding = nn.Parameter(torch.empty((vocab_dim, dim)))
+        torch.nn.init.kaiming_uniform_(self.embedding, a=math.sqrt(5))
+
+    def forward(self, x):
+
+        # Just for now 
+        normalized_embeddings = F.normalize(self.embedding[:-1], p=2, dim=-1)
+        # normalized_embeddings = normalized_embeddings * math.sqrt(self.dim)
+        
+        # normalized_embeddings = self.embedding[:-1]
+
+        if x.ndim == 2:
+            return normalized_embeddings[x]
+        assert x.ndim == 3
+
+        return torch.einsum(
+            "blv,ve->ble",
+            x.float(),
+            normalized_embeddings.float(),
+        ).to(x.dtype)
+
+
+
+class DDiTFinalLayer(nn.Module):
+    def __init__(self, hidden_size, out_channels, cond_dim, adaLN, bias=True):
+        super().__init__()
+        self.norm_final = LayerNorm(hidden_size)
+        self.linear = nn.Linear(hidden_size, out_channels, bias=bias)
+        self.linear.weight.data.zero_()
+        self.linear.bias.data.zero_()
+        self.adaLN = adaLN
+        if self.adaLN:
+            self.adaLN_modulation = nn.Linear(cond_dim, 2 * hidden_size, bias=bias)
+            self.adaLN_modulation.weight.data.zero_()
+            # if bias:
+            self.adaLN_modulation.bias.data.zero_()
+
+    def forward(self, x, c):
+        x = self.norm_final(x)
+        if self.adaLN:
+            shift, scale = self.adaLN_modulation(c)[:, None].chunk(2, dim=2)
+            x = modulate_fused(x, shift, scale)
+        x = self.linear(x)
+
+        # normalized_weight = F.normalize(self.linear.weight, p=2, dim=-1)
+        # x = F.linear(x, normalized_weight, bias=self.linear.bias)
+        return x
+
+
+# assumes that the vocab size is counting the mask token
+class DIT_CANDI(nn.Module, huggingface_hub.PyTorchModelHubMixin):
+    def __init__(self, 
+                 config, 
+                 vocab_size: int, 
+                 mixed_coeff: float=.5):
+        super().__init__()
+        if type(config) == dict:
+            config = omegaconf.OmegaConf.create(config)
+        self.causal = False
+        self.adaLN = True
+        self.config = config.model
+        self.vocab_size = vocab_size
+        dim = config.model.hidden_size
+        self.dim=dim
+        cond_dim = config.model.cond_dim
+        self.vocab_embed = EmbeddingLayer(dim,vocab_size)
+        self.mask_index = vocab_size
+
+
+        if not self.causal:
+            self.sigma_map = TimestepEmbedder(cond_dim)
+        self.rotary_emb = Rotary(dim // config.model.n_heads)
+        self.mixed_coeff = mixed_coeff
+
+
+        blocks = []
+        for _ in range(config.model.n_blocks):
+            if self.causal:
+                block = DDiTBlockCausal(
+                    dim=dim, n_heads=config.model.n_heads, dropout=config.model.dropout
+                )
+            else:
+                block = DDiTBlock(
+                    dim=dim,
+                    n_heads=config.model.n_heads,
+                    cond_dim=cond_dim,
+                    adaLN=self.adaLN,
+                    dropout=config.model.dropout,
+                )
+            blocks.append(block)
+        self.blocks = nn.ModuleList(blocks)
+
+        self.output_layer = DDiTFinalLayer(
+            hidden_size=dim,
+            out_channels=vocab_size,
+            cond_dim=cond_dim,
+            adaLN=self.adaLN,
+        )
+
+    def _get_bias_dropout_scale(self):
+        if self.training:
+            return bias_dropout_add_scale_fused_train
+        else:
+            return bias_dropout_add_scale_fused_inference
+        
+    def forward(self, xt, discrete_noise, reveal_mask, continuous_noise, **kwargs):
+        x = xt 
+        sigma = -1 * torch.log(1 - discrete_noise)
+        c_in = 1 / (1 + continuous_noise ** 2) ** .5
+
+        x = self.vocab_embed(x)
+
+        special = self.vocab_embed.embedding[-1].view(1, 1, -1).expand_as(x)
+        mask = reveal_mask.unsqueeze(-1).float()
+        coeffs = torch.ones(mask.size(0), device=mask.device)[:, None, None] * self.mixed_coeff 
+
+        # input preconditioning 
+        # for noisy positions, add corruption bias and rescale by c_in
+        x = x * mask + (1 - mask) * (coeffs * special / special.norm(dim=-1, keepdim=True)+ (1 - coeffs) * x * c_in)
+
+        t_cond = F.silu(self.sigma_map(sigma))
+
+        rotary_cos_sin = self.rotary_emb(x)
+
+        with torch.cuda.amp.autocast(dtype=torch.bfloat16):
+            for i in range(len(self.blocks)):
+                x = self.blocks[i](x, rotary_cos_sin, c=t_cond)
+            logits = self.output_layer(x, c=t_cond)
+
+        # do not return the mask token logits
+        return logits[:, :, :-1]
+    
+    def get_embedding(self, x): 
+        return self.vocab_embed(x)
+    
+    
+__all__ = ["DIT_CANDI"]

--- a/src/discrete_diffusion/noise_schedules/inverse_cdf.py
+++ b/src/discrete_diffusion/noise_schedules/inverse_cdf.py
@@ -1,0 +1,41 @@
+"""Continuous Noise schedule following inverse cdf from https://patrickpynadath1.github.io/candi-lander/candi.pdf."""
+
+import torch
+
+from .base import NoiseSchedule
+
+
+class InverseCDF(NoiseSchedule):
+    """Uses inverse Gaussian cdf to calibrate Gaussian noise schedule. sigma_t = - 1 / (phi_inverse(r*(t)) sqrt(2))"""
+
+    def __init__(
+        self, eps: float = 1e-3, r_max: float = 0.45, r_min: float = 0.05, **kwargs
+    ):
+        super().__init__()
+        self.eps = float(eps)
+        self.r_max = float(r_max)
+        self.r_min = float(r_min)
+
+    def r_t(self, t: torch.Tensor) -> torch.Tensor:
+        r_star = t * (self.r_max - self.r_min) + self.r_min
+        return r_star
+    
+    def sigma_t(self, t: torch.Tensor) -> torch.Tensor:
+        r_star = self.r_t(t)
+        # Compute Φ^(-1)(r*(t)) - inverse CDF of standard normal
+        # Using the normal distribution's inverse CDF (quantile function)
+        # equation 10 of CANDI
+        phi_inv = torch.distributions.Normal(0, 1).icdf(r_star)
+        
+        # Compute σ(t) = -1 / (Φ^(-1)(r*(t)) * √2)
+        sigma_t = -1.0 / (phi_inv * torch.sqrt(torch.tensor(2.0)))
+        return sigma_t
+
+    def alpha_t(self, t: torch.Tensor) -> torch.Tensor:
+        scaled_t = (1 - self.eps) * t
+        return 1 - scaled_t
+
+    def alpha_prime_t(self, t: torch.Tensor) -> torch.Tensor:
+        return -(1 - self.eps) * torch.ones_like(t)
+
+__all__ = ["InverseCDF"]

--- a/src/discrete_diffusion/sampling/candi_sampler.py
+++ b/src/discrete_diffusion/sampling/candi_sampler.py
@@ -1,0 +1,240 @@
+"""Hybrid sampler for CANDI."""
+
+from __future__ import annotations
+
+import torch
+
+from ..forward_process.utils import sample_categorical
+from .base import Sampler
+
+
+class CANDI_Sampler(Sampler):
+    """Base inference method that implements helper functions needed for CANDI"""
+
+    def __init__(self, config, forward_process=None, use_approx=True):
+        self.config = config
+        self.forward_process = forward_process
+        self.use_approx = use_approx
+        self.num_steps = config.sampling.steps
+
+
+    def _continuous_step(
+        self,
+        model,
+        x: torch.Tensor,
+        time_t: torch.Tensor,
+        time_s: torch.Tensor,
+        sigma_s: torch.Tensor,
+        sigma_t: torch.Tensor,
+        reveal_mask: torch.Tensor = None,
+        is_embed=False,
+    ) -> torch.Tensor:
+
+        dt_cont_vec = (
+            torch.ones(x.shape[0], device=x.device) * (sigma_s - sigma_t).item()
+        )
+        time_t_vec = torch.ones(x.shape[0], device=x.device) * time_t.item()
+        sigma_t_vec = torch.ones(x.shape[0], device=x.device) * sigma_t.item()
+        if reveal_mask is None:
+            reveal_mask = torch.zeros(x.shape[:-1], device=x.device)
+        cond_denoised = model.forward(
+            xt=x,
+            discrete_noise=time_t_vec,
+            reveal_mask=reveal_mask,
+            continuous_noise=sigma_t_vec,
+            is_embed=is_embed,
+        ).double()
+        denoised = cond_denoised.exp()
+        if self.is_embed:
+            x0_hat = self.backbone.get_embedding(denoised)
+        else:
+            x0_hat = denoised
+        d = (x - x0_hat) / (sigma_t_vec[:, None, None] ** 2)
+        x_cont = x - dt_cont_vec[:, None, None] * d
+        return x_cont, denoised
+
+    def _continuous_step_approx(
+        self,
+        model,
+        x: torch.Tensor,
+        time_t: torch.Tensor,
+        time_s: torch.Tensor,
+        sigma_s: torch.Tensor,
+        sigma_t: torch.Tensor,
+        embedding_cache: torch.Tensor,
+        reveal_mask: torch.Tensor = None,
+    ) -> torch.Tensor:
+        dt = sigma_s - sigma_t
+        time_t_vec = torch.ones(x.shape[0], device=x.device) * time_t.item()
+        sigma_t_vec = torch.ones(x.shape[0], device=x.device) * sigma_t.item()
+        if reveal_mask is None:
+            reveal_mask = torch.zeros(x.shape[:-1], device=x.device)
+        cond_denoised = model.forward(
+            xt=x,
+            discrete_noise=time_t_vec,
+            reveal_mask=reveal_mask,
+            continuous_noise=sigma_t_vec[:, None, None],
+            embedding=embedding_cache,
+        ).double()
+
+        denoised = cond_denoised.exp()
+        x0_hat = sample_categorical(denoised)
+        embedding_hat = model.backbone.get_embedding(x0_hat)
+        d = (embedding_cache - embedding_hat) / (sigma_t**2)
+        new_embedding_cache = embedding_cache - dt * d
+        return new_embedding_cache, x0_hat
+
+    def _discrete_step_approx(
+        self, x0_hat, xt, t, dt, prev_clean_mask, noise_removal_step=False
+    ):
+
+        if noise_removal_step:
+            s = 0
+        else:
+            s = t - dt
+
+        # unmasking correspends to 1-alpha(s) / 1-alpha(t)
+        # this is just s / t under a log linear schedule
+        unmask = (
+            torch.rand(prev_clean_mask.shape, device=prev_clean_mask.device)
+            < (t - s) / t
+        )
+        xt[~prev_clean_mask] = x0_hat[~prev_clean_mask]
+        new_clean_mask = prev_clean_mask | unmask
+        return xt, new_clean_mask
+
+    def _discrete_step(
+        self, x_sigma, p_x0, t, dt, prev_clean_mask, noise_removal_step=False
+    ):
+        if noise_removal_step:
+            s = 0.0
+        else:
+            s = t - dt
+
+        t_vec = torch.ones(x_sigma.shape[0], device=x_sigma.device) * t.item()
+        s_vec = torch.ones(x_sigma.shape[0], device=x_sigma.device) * s.item()
+        mask_probs = torch.ones(
+            (x_sigma.shape[0], x_sigma.shape[1], 1), device=x_sigma.device
+        ) * (s)
+        unmasked_probs = p_x0 * (t_vec - s_vec)[:, None, None]
+
+        q_xs = torch.cat([unmasked_probs, mask_probs], dim=-1)
+        _x = sample_categorical(q_xs)
+        new_clean_mask = (prev_clean_mask.bool() | (_x != self.mask_index)).float()
+
+        # For tokens that got sampled to real values (not mask), use those
+        old_x_tokens = x_sigma.argmax(dim=-1)
+
+        # For tokens that got sampled to mask, keep old tokens but mark as not clean
+        sampled_real_tokens = torch.where(_x != self.mask_index, _x, old_x_tokens)
+        # Apply copy logic: keep old tokens where prev_clean_mask is True
+        updated_tokens = torch.where(
+            prev_clean_mask.bool(), old_x_tokens, sampled_real_tokens
+        )
+        updated_x = (
+            torch.nn.functional.one_hot(updated_tokens, num_classes=x_sigma.shape[-1])
+            .float()
+            .to(x_sigma.device)
+        )
+
+        updated_x = (
+            updated_x * new_clean_mask.unsqueeze(-1)
+            + (1 - new_clean_mask).unsqueeze(-1) * x_sigma
+        )
+
+        return updated_x, new_clean_mask
+
+    def generate_samples_nocache(
+        self, model, *, num_samples, num_steps, eps, inject_bos
+    ):
+        if num_steps is None:
+            num_steps = self.config.sampling.steps
+
+        x = self.prior_sample(num_samples, model.num_tokens)
+        clean_mask = torch.zeros((num_samples, model.num_tokens), device=x.device)
+        timesteps = torch.linspace(0.999, eps, num_steps + 1, device=model.device)
+        continuous_noise = model.noise.sigma_t(timesteps)
+        dt = (1 - eps) / (num_steps)
+
+        self.max_sigma = continuous_noise.max().item()
+
+        self.prev_px0 = None
+        for i in range(num_steps):
+            t = timesteps[i]
+            s = timesteps[i + 1]
+
+            sigma_s = continuous_noise[i]
+            sigma_t = continuous_noise[i + 1]
+
+            x_cont, p_x0 = self._continuous_step(
+                model=model, 
+                x=x,
+                time_t=t,
+                time_s=s,
+                sigma_s=sigma_s,
+                sigma_t=sigma_t,
+                reveal_mask=clean_mask,
+            )
+
+            x, clean_mask = self._discrete_step(
+                x_cont, p_x0, t, dt, prev_clean_mask=clean_mask
+            )
+        final_tokens = x.argmax(dim=-1)
+        return final_tokens
+
+    # optimized function with cached embeddings
+    @torch.no_grad()
+    def generate_samples_cache(self, model, *, num_samples, num_steps, eps, inject_bos):
+        if num_steps is None:
+            num_steps = self.config.sampling.steps
+
+        x = model.prior_sample(num_samples, model.num_tokens)
+        embedding_cache = model.backbone.get_embedding(x)
+        timesteps = torch.linspace(0.999, eps, num_steps + 1, device=model.device)
+        continuous_noise = model.noise.sigma_t(timesteps)
+        clean_mask = torch.zeros(
+            (num_samples, model.num_tokens), device=x.device, dtype=torch.bool
+        )
+
+        timesteps = torch.linspace(0.999, eps, num_steps + 1, device=model.device)
+        dt = (1 - eps) / (num_steps)
+
+        self.max_sigma = continuous_noise.max().item()
+        x = x.argmax(dim=-1)
+        for i in range(num_steps):
+            t = timesteps[i]
+            s = timesteps[i + 1]
+
+            sigma_s = continuous_noise[i]
+            sigma_t = continuous_noise[i + 1]
+            embedding_cache, x0_hat = self._continuous_step_approx(
+                model=model, 
+                x=x,
+                time_t=t,
+                time_s=s,
+                sigma_s=sigma_s,
+                sigma_t=sigma_t,
+                reveal_mask=clean_mask.float(),
+                embedding_cache=embedding_cache,
+            )
+            x, clean_mask = self._discrete_step_approx(
+                x0_hat, x, t, dt, prev_clean_mask=clean_mask, noise_removal_step=False
+            )
+        return x
+    
+    def generate(
+            self, model, *, num_samples, num_steps, eps, inject_bos
+        ):
+        print(num_steps)
+        if num_steps is None:
+            num_steps = self.num_steps
+        if self.use_approx:
+            return self.generate_samples_cache(
+                model, num_samples=num_samples, num_steps=num_steps, eps=eps, inject_bos=inject_bos
+            )
+        else:
+            return self.generate_samples_nocache(
+                model, num_samples=num_samples, num_steps=num_steps, eps=eps, inject_bos=inject_bos
+            )
+    
+__all__ = ["CANDI_Sampler"]

--- a/src/discrete_diffusion/sampling/candi_sampler.py
+++ b/src/discrete_diffusion/sampling/candi_sampler.py
@@ -11,49 +11,13 @@ from .base import Sampler
 class CANDI_Sampler(Sampler):
     """Base inference method that implements helper functions needed for CANDI"""
 
-    def __init__(self, config, forward_process=None, use_approx=True):
+    def __init__(self, config, forward_process=None, **kwargs):
         self.config = config
         self.forward_process = forward_process
-        self.use_approx = use_approx
         self.num_steps = config.sampling.steps
 
 
     def _continuous_step(
-        self,
-        model,
-        x: torch.Tensor,
-        time_t: torch.Tensor,
-        time_s: torch.Tensor,
-        sigma_s: torch.Tensor,
-        sigma_t: torch.Tensor,
-        reveal_mask: torch.Tensor = None,
-        is_embed=False,
-    ) -> torch.Tensor:
-
-        dt_cont_vec = (
-            torch.ones(x.shape[0], device=x.device) * (sigma_s - sigma_t).item()
-        )
-        time_t_vec = torch.ones(x.shape[0], device=x.device) * time_t.item()
-        sigma_t_vec = torch.ones(x.shape[0], device=x.device) * sigma_t.item()
-        if reveal_mask is None:
-            reveal_mask = torch.zeros(x.shape[:-1], device=x.device)
-        cond_denoised = model.forward(
-            xt=x,
-            discrete_noise=time_t_vec,
-            reveal_mask=reveal_mask,
-            continuous_noise=sigma_t_vec,
-            is_embed=is_embed,
-        ).double()
-        denoised = cond_denoised.exp()
-        if self.is_embed:
-            x0_hat = self.backbone.get_embedding(denoised)
-        else:
-            x0_hat = denoised
-        d = (x - x0_hat) / (sigma_t_vec[:, None, None] ** 2)
-        x_cont = x - dt_cont_vec[:, None, None] * d
-        return x_cont, denoised
-
-    def _continuous_step_approx(
         self,
         model,
         x: torch.Tensor,
@@ -84,7 +48,7 @@ class CANDI_Sampler(Sampler):
         new_embedding_cache = embedding_cache - dt * d
         return new_embedding_cache, x0_hat
 
-    def _discrete_step_approx(
+    def _discrete_step(
         self, x0_hat, xt, t, dt, prev_clean_mask, noise_removal_step=False
     ):
 
@@ -103,88 +67,8 @@ class CANDI_Sampler(Sampler):
         new_clean_mask = prev_clean_mask | unmask
         return xt, new_clean_mask
 
-    def _discrete_step(
-        self, x_sigma, p_x0, t, dt, prev_clean_mask, noise_removal_step=False
-    ):
-        if noise_removal_step:
-            s = 0.0
-        else:
-            s = t - dt
-
-        t_vec = torch.ones(x_sigma.shape[0], device=x_sigma.device) * t.item()
-        s_vec = torch.ones(x_sigma.shape[0], device=x_sigma.device) * s.item()
-        mask_probs = torch.ones(
-            (x_sigma.shape[0], x_sigma.shape[1], 1), device=x_sigma.device
-        ) * (s)
-        unmasked_probs = p_x0 * (t_vec - s_vec)[:, None, None]
-
-        q_xs = torch.cat([unmasked_probs, mask_probs], dim=-1)
-        _x = sample_categorical(q_xs)
-        new_clean_mask = (prev_clean_mask.bool() | (_x != self.mask_index)).float()
-
-        # For tokens that got sampled to real values (not mask), use those
-        old_x_tokens = x_sigma.argmax(dim=-1)
-
-        # For tokens that got sampled to mask, keep old tokens but mark as not clean
-        sampled_real_tokens = torch.where(_x != self.mask_index, _x, old_x_tokens)
-        # Apply copy logic: keep old tokens where prev_clean_mask is True
-        updated_tokens = torch.where(
-            prev_clean_mask.bool(), old_x_tokens, sampled_real_tokens
-        )
-        updated_x = (
-            torch.nn.functional.one_hot(updated_tokens, num_classes=x_sigma.shape[-1])
-            .float()
-            .to(x_sigma.device)
-        )
-
-        updated_x = (
-            updated_x * new_clean_mask.unsqueeze(-1)
-            + (1 - new_clean_mask).unsqueeze(-1) * x_sigma
-        )
-
-        return updated_x, new_clean_mask
-
-    def generate_samples_nocache(
-        self, model, *, num_samples, num_steps, eps, inject_bos
-    ):
-        if num_steps is None:
-            num_steps = self.config.sampling.steps
-
-        x = self.prior_sample(num_samples, model.num_tokens)
-        clean_mask = torch.zeros((num_samples, model.num_tokens), device=x.device)
-        timesteps = torch.linspace(0.999, eps, num_steps + 1, device=model.device)
-        continuous_noise = model.noise.sigma_t(timesteps)
-        dt = (1 - eps) / (num_steps)
-
-        self.max_sigma = continuous_noise.max().item()
-
-        self.prev_px0 = None
-        for i in range(num_steps):
-            t = timesteps[i]
-            s = timesteps[i + 1]
-
-            sigma_s = continuous_noise[i]
-            sigma_t = continuous_noise[i + 1]
-
-            x_cont, p_x0 = self._continuous_step(
-                model=model, 
-                x=x,
-                time_t=t,
-                time_s=s,
-                sigma_s=sigma_s,
-                sigma_t=sigma_t,
-                reveal_mask=clean_mask,
-            )
-
-            x, clean_mask = self._discrete_step(
-                x_cont, p_x0, t, dt, prev_clean_mask=clean_mask
-            )
-        final_tokens = x.argmax(dim=-1)
-        return final_tokens
-
-    # optimized function with cached embeddings
     @torch.no_grad()
-    def generate_samples_cache(self, model, *, num_samples, num_steps, eps, inject_bos):
+    def generate(self, model, *, num_samples, num_steps, eps, inject_bos):
         if num_steps is None:
             num_steps = self.config.sampling.steps
 
@@ -207,7 +91,7 @@ class CANDI_Sampler(Sampler):
 
             sigma_s = continuous_noise[i]
             sigma_t = continuous_noise[i + 1]
-            embedding_cache, x0_hat = self._continuous_step_approx(
+            embedding_cache, x0_hat = self._continuous_step(
                 model=model, 
                 x=x,
                 time_t=t,
@@ -217,24 +101,10 @@ class CANDI_Sampler(Sampler):
                 reveal_mask=clean_mask.float(),
                 embedding_cache=embedding_cache,
             )
-            x, clean_mask = self._discrete_step_approx(
+            x, clean_mask = self._discrete_step(
                 x0_hat, x, t, dt, prev_clean_mask=clean_mask, noise_removal_step=False
             )
         return x
     
-    def generate(
-            self, model, *, num_samples, num_steps, eps, inject_bos
-        ):
-        print(num_steps)
-        if num_steps is None:
-            num_steps = self.num_steps
-        if self.use_approx:
-            return self.generate_samples_cache(
-                model, num_samples=num_samples, num_steps=num_steps, eps=eps, inject_bos=inject_bos
-            )
-        else:
-            return self.generate_samples_nocache(
-                model, num_samples=num_samples, num_steps=num_steps, eps=eps, inject_bos=inject_bos
-            )
     
 __all__ = ["CANDI_Sampler"]


### PR DESCRIPTION
## Summary
This PR adds support for the CANDI (Continuous and Discrete Diffusion) model from this paper: https://arxiv.org/pdf/2510.22510.

## Changes
- Added CANDI model configurations 
- Added CANDI training algorithm, noise scheduling, hybrid corruption kernel, and inference algorithm

## Key Files Changed
- `src/discrete_diffusion/forward_process/candi_hybrid.py` - Hybrid corruption kernel 
- `src/discrete_diffusion/noise_schedules/inverse_cdf.py` - Inverse cdf continuous noise scheduling with log linear discrete noise 
- `src/discrete_diffusion/algo/candi.py` - main training algorithm 
- `src/discrete_diffusion/sampling/candi_sampler.py` -  implementation of candi approximate sampler 
- `src/discrete_diffusion/models/dit_candi.py` -  CANDI DiT with continuous preconditioning logic 

## Testing
- Tested on text8 with 8 million parameter model for both training and inference -- may need additional testing for OWT