### PR TITLE
Fix/rope cache dtype

### DIFF
--- a/src/discrete_diffusion/models/common.py
+++ b/src/discrete_diffusion/models/common.py
@@ -155,8 +155,9 @@ class Rotary(torch.nn.Module):
 
     if seq_len != self.seq_len_cached:
       self.seq_len_cached = seq_len
-      t = torch.arange(seq_len, device=device).type_as(self.inv_freq)
-      freqs = torch.einsum("i,j->ij", t, self.inv_freq.clone())
+      inv_freq = self.inv_freq.to(device=device, dtype=torch.float32)
+      t = torch.arange(seq_len, device=device, dtype=torch.float32)
+      freqs = torch.einsum("i,j->ij", t, inv_freq)
       emb = torch.cat((freqs, freqs), dim=-1).to(device)
       # dims are: batch, seq_len, qkv, head, dim
       self.cos_cached = emb.cos()[None, :, None, None, :].repeat(1, 1, 3, 1, 1)

--- a/src/discrete_diffusion/models/flexmdm_transformer.py
+++ b/src/discrete_diffusion/models/flexmdm_transformer.py
@@ -143,10 +143,9 @@ class Rotary(torch.nn.Module):
     seq_len = x.shape[seq_dim]
     if seq_len != self.seq_len_cached:
       self.seq_len_cached = seq_len
-      t = torch.arange(x.shape[seq_dim], device=x.device).type_as(
-        self.inv_freq
-      )
-      freqs = torch.einsum("i,j->ij", t, self.inv_freq.clone())
+      inv_freq = self.inv_freq.to(device=x.device, dtype=torch.float32)
+      t = torch.arange(x.shape[seq_dim], device=x.device, dtype=torch.float32)
+      freqs = torch.einsum("i,j->ij", t, inv_freq)
       emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
       # Dims: batch, seq_len, qkv, head, dim
       self.cos_cached = emb.cos()[None, :, None, None, :].repeat(1, 1, 3, 1, 1)


### PR DESCRIPTION
## Summary

Fix RoPE cache construction so rotary phases are computed in float32 even when the model is cast to bf16/fp16.

## Motivation

This follows the pattern used in mainstream RoPE implementations: the phase construction is protected in higher precision, while the final cos/sin values can still be consumed in the model's activation dtype.

This matters for bf16 because positions above 256 can no longer represent every consecutive integer exactly. The position sequence starts to alias or skip values, so the RoPE cache can encode malformed ordering.

That failure mode is especially important for BREVO (Physics of Language Models 4) where exact ordering across the constructed sequence is crucial.

## Fix

The old code made RoPE positions inherit the dtype of inv_freq:

torch.arange(...).type_as(self.inv_freq)

Since inv_freq is a registered buffer, model-level dtype casts can turn it into bf16/fp16. Cloning the buffer does not help because the clone keeps the already-downcast dtype.

This PR computes both RoPE phase inputs explicitly in float32:

- inv_freq is converted with dtype=torch.float32
- position indices are created with dtype=torch.float32
- the frequency matrix is built from those float32 tensors